### PR TITLE
Add deploy-version-api: signed-commits sibling of deploy-version

### DIFF
--- a/deploy-version-api/action.yml
+++ b/deploy-version-api/action.yml
@@ -1,0 +1,173 @@
+name: "Deploys new version to k8s (signed via GitHub API)"
+description: |
+  Drop-in equivalent of `deploy-version` that publishes the bump
+  through the GitHub Git Data API instead of `git push`. Identical
+  inputs, identical YAML edits, identical commit-message shape — the
+  only difference is the publish step.
+  Why this matters: API-created commits are auto-signed by GitHub's
+  `web-flow` key and show as "Verified". Repos with a "Commits must
+  have verified signatures" branch-protection rule accept them; the
+  same workflow using `deploy-version` would be rejected because the
+  bot's `git push` is unsigned.
+  Use this action when the target GitOps repo enforces verified
+  signatures. Otherwise either action works the same way.
+inputs:
+  repo:
+    description: "GitOps Repo"
+    required: false
+    default: "iac-config"
+  required_pr_label:
+    description: "PR label that should be present"
+    required: false
+    default: ""
+  version:
+    description: "Image version"
+    required: true
+  services:
+    description: "Service paths to update version, each path can be in a new line"
+    required: true
+  gh_token:
+    description: "Github PAT with contents:write on the GitOps repo"
+    required: true
+  branch:
+    description: "Target branch on the GitOps repo"
+    required: false
+    default: "main"
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+    - uses: chrisdickinson/setup-yq@latest
+      with:
+        yq-version: v4.43.1
+    - uses: jwalton/gh-find-current-pr@master
+      id: findPr
+      if: inputs.required_pr_label != ''
+      with:
+        state: all
+    - uses: snnaplab/get-labels-action@v1
+      if: steps.findPr.outputs.number != ''
+      id: prLabels
+      with:
+        number: ${{ steps.findPr.outputs.number }}
+    - name: Exit if label not set
+      if: inputs.required_pr_label != '' && (steps.findPr.outputs.number == '' || !contains(fromJSON(steps.prLabels.outputs.labels), inputs.required_pr_label))
+      shell: bash
+      env:
+        TEST: ${{ steps.prLabels.outputs.labels }}
+      run: exit 1
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository_owner }}/${{ inputs.repo }}
+        path: ${{ inputs.repo }}
+        token: ${{ inputs.gh_token }}
+    - name: Update versions + commit via GitHub API
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh_token }}
+        PR_NUM: ${{ steps.findPr.outputs.number }}
+        PR_TITLE: ${{ steps.findPr.outputs.title }}
+        CURRENT_REPO: ${{ github.repository }}
+        REPO: ${{ inputs.repo }}
+        VERSION: ${{ inputs.version }}
+        SERVICE_PATHS: ${{ inputs.services }}
+        OWNER: ${{ github.repository_owner }}
+        BRANCH: ${{ inputs.branch }}
+      run: |
+        set -euo pipefail
+        cd "$REPO"
+        FULL_REPO="$OWNER/$REPO"
+
+        # ── 1. YAML edits — identical to deploy-version. We do them on
+        #      the working tree so we can reuse `git diff --name-only`
+        #      to discover what actually changed (handles re-runs where
+        #      the version is already at $VERSION → no-op cleanly).
+        cd services
+        while read -r service; do
+          if [[ -z "$service" ]]; then continue; fi
+          echo "Updating version to $VERSION for $service"
+          if [[ -f "$service/kustomization.yaml" ]]; then
+            yq e '.helmCharts[0].valuesInline.global.version = env(VERSION)' -i "$service/kustomization.yaml"
+          elif [[ -f "$service/values.yaml" ]]; then
+            yq e '.global.version = env(VERSION)' -i "$service/values.yaml"
+          else
+            echo "Config yaml not detected, please check the path is correct!" && exit 2
+          fi
+        done <<< "$SERVICE_PATHS"
+        cd ..
+
+        # ── 2. Find changed files. Empty diff = nothing to commit; bail
+        #      cleanly so re-runs of an already-deployed version don't
+        #      fail the workflow.
+        CHANGED=$(git diff --name-only)
+        if [[ -z "$CHANGED" ]]; then
+          echo "No changes — version is already $VERSION on $BRANCH"
+          exit 0
+        fi
+        echo "Changed files:"
+        echo "$CHANGED"
+
+        # ── 3. Commit message — identical shape to deploy-version, with
+        #      the same indentation when a PR number is present.
+        commit="[${CURRENT_REPO#*/}]: Update version to $VERSION"
+        if [[ -n "${PR_NUM:-}" ]]; then
+          commit="$commit
+
+          Automated deployment for PR: https://github.com/$CURRENT_REPO/pull/$PR_NUM
+          PR Title: '$PR_TITLE'"
+        fi
+
+        # ── 4. Snapshot the current branch tip + its tree. We base the
+        #      new tree on this, so files we don't touch carry through
+        #      unchanged. (Without `base_tree` the resulting commit
+        #      would contain ONLY the files we POST — every other file
+        #      in the repo would vanish.)
+        HEAD_SHA=$(gh api "repos/$FULL_REPO/git/ref/heads/$BRANCH" --jq .object.sha)
+        BASE_TREE=$(gh api "repos/$FULL_REPO/git/commits/$HEAD_SHA" --jq .tree.sha)
+
+        # ── 5. Create one blob per changed file, accumulate the tree
+        #      entries as a JSON array. Files mode 100644 — regular
+        #      file. We keep the original POSIX file mode by re-using
+        #      `git ls-files --stage` lookup so executable bits / symlinks
+        #      survive (kustomization.yaml is always 100644 in practice;
+        #      this guards against future YAML files that aren't).
+        TREE_JSON='[]'
+        while IFS= read -r path; do
+          [[ -z "$path" ]] && continue
+          # Capture mode from the working tree's index. Falls back to
+          # 100644 if ls-files doesn't know it (untracked files —
+          # shouldn't happen here since yq edits in place, but defensive).
+          MODE=$(git ls-files --stage -- "$path" | awk '{print $1}')
+          MODE="${MODE:-100644}"
+          BLOB_SHA=$(gh api -X POST "repos/$FULL_REPO/git/blobs" \
+            -f content="$(base64 -w0 < "$path")" \
+            -f encoding=base64 \
+            --jq .sha)
+          TREE_JSON=$(echo "$TREE_JSON" | jq --arg p "$path" --arg s "$BLOB_SHA" --arg m "$MODE" \
+            '. += [{path: $p, mode: $m, type: "blob", sha: $s}]')
+        done <<< "$CHANGED"
+
+        # ── 6. Build the new tree on top of the parent. ONE tree
+        #      regardless of how many files changed.
+        NEW_TREE=$(gh api -X POST "repos/$FULL_REPO/git/trees" \
+          -f base_tree="$BASE_TREE" \
+          --raw-field tree="$TREE_JSON" \
+          --jq .sha)
+
+        # ── 7. Create the commit. API-created commits are auto-signed
+        #      by GitHub's web-flow key as the authenticated user — this
+        #      satisfies "Commits must have verified signatures" rules.
+        NEW_COMMIT=$(gh api -X POST "repos/$FULL_REPO/git/commits" \
+          -f message="$commit" \
+          -f tree="$NEW_TREE" \
+          -f parents[]="$HEAD_SHA" \
+          --jq .sha)
+
+        # ── 8. Fast-forward the branch ref. `force=false` rejects
+        #      non-fast-forwards — if someone else pushed between step
+        #      4 and now, fail loudly rather than clobber.
+        gh api -X PATCH "repos/$FULL_REPO/git/refs/heads/$BRANCH" \
+          -f sha="$NEW_COMMIT" \
+          -F force=false
+
+        echo "Pushed verified commit $NEW_COMMIT to $FULL_REPO@$BRANCH"


### PR DESCRIPTION
## Summary

A new composite action `deploy-version-api` that's a drop-in equivalent of `deploy-version` — same inputs, same YAML edit logic, same commit-message shape — except it publishes the bump through the GitHub **Git Data API** instead of \`git push\`.

The reason: API-created commits are auto-signed by GitHub's \`web-flow\` key, so they satisfy "Commits must have verified signatures" branch-protection rules. \`deploy-version\` currently fails on those repos because the bot's \`git push\` is unsigned.

## Why a new action instead of modifying `deploy-version`?

Zero risk to existing consumers of \`deploy-version\` — they keep working unchanged. Once every consumer has migrated to \`deploy-version-api\`, the old one can be deleted in a follow-up. Avoids carrying a \`commit_via: 'git' | 'api'\` switch forever.

## How it differs from `deploy-version`

| | `deploy-version` | `deploy-version-api` |
|---|---|---|
| Inputs | `repo`, `required_pr_label`, `version`, `services`, `gh_token` | identical (plus optional `branch`, defaults to `main`) |
| YAML edit | `yq -i` on local working tree | identical |
| Commit shape | one commit per workflow run, all changed files | identical |
| Publish | `git commit && git push origin main` | `POST /git/blobs` per file → `POST /git/trees` → `POST /git/commits` → `PATCH /git/refs` |
| Result | unsigned commit, 4 lines of bash | verified commit, ~30 lines of bash |

## Edge cases

- **No changes** (re-running for an already-deployed version) → exits cleanly. \`deploy-version\` would fail on \`git commit\` with "nothing to commit".
- **Race**: \`force=false\` on the ref update — if someone else pushed between fetching HEAD and pushing the new ref, the action fails loudly rather than clobber.
- **File mode** preserved via \`git ls-files --stage\` lookup so future executable / symlink files survive (kustomization.yaml is always 100644 today).
- **\`base_tree\`** is always passed when creating the tree — without it, every file not in the tree array would vanish from the repo.

## Caller migration

\`\`\`yaml
- uses: Polynomial-Protocol/that-broken-pipe/deploy-version-api@main
  with:
    services: |
      fxyz-api/testnet
    version: \${{ needs.api.outputs.version }}
    gh_token: \${{ secrets.GH_PAT }}
\`\`\`

Identical input shape to \`deploy-version\` — the migration is a one-line \`uses:\` swap. \`fxyz-new\` will move to this action once it's merged; that unblocks its CD which has been failing on iac-config's signature rule for the past few hours.

## Test plan

- [ ] Tested locally by hand: cloned iac-config, ran the API calls, verified resulting commit shows "Verified" badge in iac-config web UI
- [ ] After merge, switch fxyz-new's \`cd-build.yml\` to \`deploy-version-api@main\` and confirm a CD run lands a verified commit on iac-config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new composite GitHub Action for automated version deployment to GitOps repositories. Updates version fields across service paths and creates commits via GitHub API with optional PR label validation, automatic branch management, and support for multi-service deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->